### PR TITLE
Fix bluebird dep is not a devdependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "eventemitter2": "^4.1.0",
     "fs-extra": "^2.1.2",
     "lodash": "^4.17.4",
+    "bluebird": "^3.5.0",
     "wireless-tools": "^0.19.0"
   },
   "devDependencies": {
-    "bluebird": "^3.5.0",
     "chai": "^3.5.0",
     "conventional-changelog-lint": "^1.1.9",
     "conventional-commits-detector": "^0.1.1",


### PR DESCRIPTION
Wirelesser was failing when using because it could not find the bluebird library.
The problem is that it is declared as a devdependency.
I moved it to the "normal" dependencies.